### PR TITLE
More .travis.yml things. (#20)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,16 @@ matrix:
     compiler: clang
 install:
 - cd $TRAVIS_BUILD_DIR/../
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x getlinuxdeps.sh && ./getlinuxdeps.sh;
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x $TRAVIS_BUILD_DIR/getlinuxdeps.sh && $TRAVIS_BUILD_DIR/getlinuxdeps.sh;
   fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then source /opt/qt56/bin/qt56-env.sh
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x getosxdeps.sh && ./getosxdeps.sh;
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then source /opt/qt56/bin/qt56-env.sh; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x $TRAVIS_BUILD_DIR/getosxdeps.sh && $TRAVIS_BUILD_DIR/getosxdeps.sh;
   fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$PATH:/usr/local/opt/qt5/bin; fi
 script:
-- cd $TRAVIS_BUILD_DIR
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export ARMA_HDF5_INCLUDE_DIR=/usr/local/opt/hdf5/include;
-  fi
-- mkdir ../build && cd ../build
-- qmake ../buildall.pro
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export ARMA_HDF5_INCLUDE_DIR=/usr/local/opt/hdf5/include; fi
+- mkdir $TRAVIS_BUILD_DIR/../build && cd $TRAVIS_BUILD_DIR/../build
+- qmake $TRAVIS_BUILD_DIR/buildall.pro
 - make
 after_success:
 - export BUILD_DIR=$TRAVIS_BUILD_DIR/../build
@@ -35,23 +34,21 @@ after_success:
   $TRAVIS_BUILD_DIR/../; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DEPLOY_DIR=$TRAVIS_BUILD_DIR/../Vespucci.app;
   fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x deploymac.sh && ./deploymac.sh
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x $TRAVIS_BUILD_DIR/deploymac.sh && $TRAVIS_BUILD_DIR/deploymac.sh
   $SRC_DIR $BUILD_DIR $DEPLOY_DIR $LIB_DIR; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x createdmg.sh && ./createdmg.sh
-  $DEPLOY_DIR $OUT_PKG $SRC_DIR
-- if [[ "TRAVIS_OS_NAME" == "linux" ]]; then export $OUT_PKG=$PKG_DIR/$PKG_NAME.tar.gz
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then chmod +x $TRAVIS_BUILD_DIR/createdmg.sh && $TRAVIS_BUILD_DIR/createdmg.sh
+  $DEPLOY_DIR $OUT_PKG $SRC_DIR; fi
+- if [[ "TRAVIS_OS_NAME" == "linux" ]]; then export $OUT_PKG=$PKG_DIR/$PKG_NAME.tar.gz; fi
 - if [[ "TRAVIS_OS_NAME" == "linux" ]]; then export DEPLOY_DIR=$TRAVIS_BUILD_DIR/Vespucci_$TRAVIS_COMMIT
   && mkdir DEPLOY_DIR; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x deploylinux.sh && ./deploylinux.sh
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x $TRAVIS_BUILD_DIR/deploylinux.sh && $TRAVIS_BUILD_DIR/deploylinux.sh
   $SRC_DIR $BUILD_DIR $DEPLOY_DIR $LIB_DIR; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x createtarball.sh && ./createtarball.sh $DEPLOY_DIR $OUT_PKG $SRC_DIR; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then chmod +x $TRAVIS_BUILD_DIR/createtarball.sh && $TRAVIS_BUILD_DIR/createtarball.sh $DEPLOY_DIR $OUT_PKG $SRC_DIR; fi
 
 deploy:
 - skip_cleanup: true
 - provider: bintray
-bintray:
-    file: deploybintray.json
-    user: dpfoose
-    key:
-        secure: CkzrPKCuAAQxnPSEXbtIbJzjFP1dDDQs0KdyxA10KvTapEOp/JppsUd2BQ7PRSIU1vdvLZM7ysnpMWsjAZQ2+MR5HxBBKRjgqjwy93XFgXS+RP36AagQIEhlu+aqvbDl9/cgMAxrj57lizQA2KUF+zIkonKByDmVNc6oExlUq0WfeCNQZ+RBb7aPfckVdViMsTtfP/3S56cY4kgcc+uVx9Au/YXTB+BHFiON7TL40CLm+FW3HArvBrmIQIBDNE50JfSBe+jCk2/wPFZnsv0FH6KcnT32cNiT2b8gUltOpHWoPbh2y5cRur6NgaAg+WaXy3XIb2KhphkA4ih5WhXGgJ+6X7V+DX1lJd/2abSJzstI+RfPnuIOxP4KjijjdhT96Gq9OLVAYT7VUcM+IyWmu/0PJCWlnFb03uJRos4QJ05QV8FxWD8K80TwfN3BIPvPwlN+uIaTsuGV6LSXIpj8zrBToM8r990kbDunxEAPBKZEP9SCpUT/26UPOp0ON2oMRSAgcFOw7c0nz+fkShWqzlaQ/VXZL4/4TYlga3ZGGWPDiEMQ0GUKZHylZZ11SrI4kuHbspGCBTb5xMrFqJ2pI+zUlPKSsInnDUHa+VDAUb0FoTwX/wSBnO6pQvT19LQLGIORMfOhTYARmz+6ChEGr4X5iO6+PQDGe95oJzy4tVI=
-  
+- file: $TRAVIS_BUILD_DIR/deploybintray.json
+- user: dpfoose
+- key:
+    secure: CkzrPKCuAAQxnPSEXbtIbJzjFP1dDDQs0KdyxA10KvTapEOp/JppsUd2BQ7PRSIU1vdvLZM7ysnpMWsjAZQ2+MR5HxBBKRjgqjwy93XFgXS+RP36AagQIEhlu+aqvbDl9/cgMAxrj57lizQA2KUF+zIkonKByDmVNc6oExlUq0WfeCNQZ+RBb7aPfckVdViMsTtfP/3S56cY4kgcc+uVx9Au/YXTB+BHFiON7TL40CLm+FW3HArvBrmIQIBDNE50JfSBe+jCk2/wPFZnsv0FH6KcnT32cNiT2b8gUltOpHWoPbh2y5cRur6NgaAg+WaXy3XIb2KhphkA4ih5WhXGgJ+6X7V+DX1lJd/2abSJzstI+RfPnuIOxP4KjijjdhT96Gq9OLVAYT7VUcM+IyWmu/0PJCWlnFb03uJRos4QJ05QV8FxWD8K80TwfN3BIPvPwlN+uIaTsuGV6LSXIpj8zrBToM8r990kbDunxEAPBKZEP9SCpUT/26UPOp0ON2oMRSAgcFOw7c0nz+fkShWqzlaQ/VXZL4/4TYlga3ZGGWPDiEMQ0GUKZHylZZ11SrI4kuHbspGCBTb5xMrFqJ2pI+zUlPKSsInnDUHa+VDAUb0FoTwX/wSBnO6pQvT19LQLGIORMfOhTYARmz+6ChEGr4X5iO6+PQDGe95oJzy4tVI=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Vespucci 
 ========
-[!["travis_ci_status"](https://travis-ci.org/VespucciProject/Vespucci.svg?branch=master)](https://travis-ci.org/VespucciProject/Vespucci) [![Build status](https://ci.appveyor.com/api/projects/status/3v1voa5sim7whv55?svg=true)](https://ci.appveyor.com/project/VespucciProject/vespucci)
+[![Build status](https://ci.appveyor.com/api/projects/status/yvo16f9ojkkkxi56?svg=true)](https://ci.appveyor.com/project/dpfoose/vespucci) [!["travis_ci_status"](https://travis-ci.org/VespucciProject/Vespucci.svg?branch=master)](https://travis-ci.org/VespucciProject/Vespucci)  
 
 This branch is the active branch of the project and, while more stable than the branches of individual contributors, is **probably not stable**.
 
@@ -24,50 +24,26 @@ After 1.0.0, 1.n+1.0 will contain new features to 1.n.0, but will have an API th
 
 Compiling Vespucci:
 ===================
-Compiling Vespucci from source is easy on Unix-like systems. Assuming you
-have the proper pre-requisites (and Vespucci.pro is properly edited to reflect
-their paths):
-
-    qmake && make && make install
-
-Should do the trick. This does not require elevation as the default install path
-is two directories above the source. You can modify PREFIX to install to a different
-directory if you'd like. If you are not compiling with static Qt, and the Qt linked
-libraries are not in your path, you will have to deploy Qt (using windeployqt or macdeployqt)
-
-The file deploymac.sh can be run to make the .app file run on Mac OS X, assuming that you used homebrew to install all dependencies.
+Compiling Vespucci from source is not the easiest but still possible. Look at 
+.travis.yml for linux and mac builds and appveyor.yml for windows builds.
 
 Pre-requisites:
 --------------------
-If you can compile and install MLPACK and have the Qt framework installed,
-then you can compile and install Vespucci. You should have the following
-libraries on your system:
+Vespucci has the following prerequisites:
+* Qt 5.5+
+* Armadillo (with BLAS/LAPACK and HDF5)
+* mlpack
+* yaml-cpp
+* quazip
 
-* Qt
-* MLPACK
-* Armadillo (compiled shared or static library)
-* LAPACK and BLAS (or high speed replacement like OpenBLAS, Accelerate, MKL, etc.)
-* ARPACK (or ARPACK-ng)
-* Boost (program_options, unit_test_framework, random, and math (c99))
-* LibXML2
-* Vespucci-QCP (compiled shared or static library, a fork of QCustomPlot https://github.com/dpfoose/Vespucci-QCP)
+Look at the scripts used by .travis.yml and appveyor.yml to figure out how to
+build on your platform.
 
-All of the above packages, with the exception of MLPACK and QCustomPlot, are 
-readily available from most major GNU/Linux repositories. Installation on Mac
-OS is similarly easy, so long as all dependencies are installed with homebrew. You may need to edit armadillo’s configure configuration to disable the wrapper.
-
-Because it is difficult to find Windows binaries for Armadillo, MLPACK and ARPACK,
-and to make development on Windows easier, I have included Windows binaries of all
-requisite libraries in the MinGW_libs repo. These are compiled with MinGW-w64 
-version 3 (GCC 4.8.2) with SEH for exception handling. The MSVC repo includes the prerequisites compiled using Visual Studio 14.0 (2015).
-
-The included Qt profile uses the library paths used by Ubuntu's package manager.
-Mac OS dependences are installed with homebrew.
-
-For Unix-like systems, shared libraries are the default. You will need to
-compile and install static versions of these libraries if you want a stand-alone executable.
-
-Windows dependencies can mostly be installed using NuGet.
+Binary Distributions:
+======================
+View the releases tab to download the latest binaries for your platform. Included
+in the distribution is the Vespucci binary, the Vespucci C++ library, and the
+Vespucci library headers.
 
 
  

--- a/Test/Test.pro
+++ b/Test/Test.pro
@@ -40,6 +40,8 @@ HEADERS += test.h \
 
 unix:!macx{
     QMAKE_CXX=/usr/bin/g++-4.9
+    CONFIG += c++11
+    QMAKE_CXXFLAGS += -fext-numeric-literals
     LIBS += -L$$PWD/../../mlpack/lib -lmlpack
     LIBS += -L$$PWD/../../armadillo/lib -larmadillo
     LIBS += -L/usr/lib -larpack
@@ -48,13 +50,15 @@ unix:!macx{
     PRE_TARGETDEPS += /usr/lib/x86_64-linux-gnu/libhdf5.a
     LIBS += -L/usr/lib -lblas
     LIBS += -L/usr/lib -llapack
-    LIBS += -L$$PWD/../../yaml-cpp/lib -llibyaml-cpp
+    LIBS += -L$$PWD/../../yaml-cpp/lib -lyaml-cpp
     PRE_TARGETDEPS += $$PWD/../../yaml-cpp/lib/libyaml-cpp.a
-    LIBS += -L$$PWD/../../quazip/lib -llibquazip
+    LIBS += -L$$PWD/../../quazip/lib -lquazip
     PRE_TARGETDEPS += $$PWD/../../quazip/lib/libquazip.a
 
-    CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/VespucciLibrary/debug -lvespucci
-    else: CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/VespucciLibrary/release -lvespucci
+    LIBS += -L/usr/lib/x86_64-linux-gnu/ -lz
+    PRE_TARGETDEPS += /usr/lib/x86_64-linux-gnu/libz.a
+
+    LIBS += -L$$OUT_PWD/../VespucciLibrary -lvespucci
 
     INCLUDEPATH += /usr/include
     DEPENDPATH += /usr/include
@@ -64,6 +68,18 @@ unix:!macx{
 
     INCLUDEPATH += /usr/local/include
     DEPENDPATH += /usr/local/include
+
+    INCLUDEPATH += $$PWD/../../mlpack/include
+    DEPENDPATH += $$PWD/../../mlpack/include
+
+    INCLUDEPATH += $$PWD/../../armadillo/include
+    DEPENDPATH += $$PWD/../../armadillo/include
+
+    INCLUDEPATH += $$PWD/../../quazip/include
+    DEPENDPATH += $$PWD/../../quazip/include
+
+    INCLUDEPATH += $$PWD/../../yaml-cpp/include
+    DEPENDPATH += $$PWD/../../yaml-cpp/include
 
 }
 
@@ -76,7 +92,6 @@ macx{
     CONFIG += app_bundle c++11
     QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
 
-    ICON = vespuccilogo.icns
     LIBS += -L/usr/lib -lc++
 
     LIBS += -L$$OUT_PWD/../VespucciLibrary/ -lvespucci

--- a/Vespucci/Vespucci.pro
+++ b/Vespucci/Vespucci.pro
@@ -276,6 +276,8 @@ DEPENDPATH += $$PWD/../VespucciLibrary/include
 
 unix:!macx{
     QMAKE_CXX=/usr/bin/g++-4.9
+    CONFIG += c++11
+    QMAKE_CXXFLAGS += -fext-numeric-literals
     LIBS += -L$$PWD/../../mlpack/lib -lmlpack
     LIBS += -L$$PWD/../../armadillo/lib -larmadillo
     LIBS += -L/usr/lib -larpack
@@ -285,13 +287,15 @@ unix:!macx{
     LIBS += -L/usr/lib -lblas
     LIBS += -L/usr/lib -llapack
 
-    LIBS += -L$$PWD/../../yaml-cpp/lib -llibyaml-cpp
+    LIBS += -L$$PWD/../../yaml-cpp/lib -lyaml-cpp
     PRE_TARGETDEPS += $$PWD/../../yaml-cpp/lib/libyaml-cpp.a
-    LIBS += -L$$PWD/../../quazip/lib -llibquazip
+    LIBS += -L$$PWD/../../quazip/lib -lquazip
     PRE_TARGETDEPS += $$PWD/../../quazip/lib/libquazip.a
 
-    CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/VespucciLibrary/debug -lvespucci
-    else: CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/VespucciLibrary/release -lvespucci
+    LIBS += -L$$OUT_PWD/../VespucciLibrary -lvespucci
+
+    LIBS += -L/usr/lib/x86_64-linux-gnu/ -lz
+    PRE_TARGETDEPS += /usr/lib/x86_64-linux-gnu/libz.a
 
     INCLUDEPATH += /usr/include
     DEPENDPATH += /usr/include
@@ -301,6 +305,18 @@ unix:!macx{
 
     INCLUDEPATH += /usr/local/include
     DEPENDPATH += /usr/local/include
+
+    INCLUDEPATH += $$PWD/../../mlpack/include
+    DEPENDPATH += $$PWD/../../mlpack/include
+
+    INCLUDEPATH += $$PWD/../../armadillo/include
+    DEPENDPATH += $$PWD/../../armadillo/include
+
+    INCLUDEPATH += $$PWD/../../quazip/include
+    DEPENDPATH += $$PWD/../../quazip/include
+
+    INCLUDEPATH += $$PWD/../../yaml-cpp/include
+    DEPENDPATH += $$PWD/../../yaml-cpp/include
 
 }
 

--- a/VespucciLibrary/VespucciLibrary.pro
+++ b/VespucciLibrary/VespucciLibrary.pro
@@ -126,9 +126,14 @@ HEADERS  += \
     include/Math/Stats/hypothesistests.h \
     include/Math/PeakFinding/kernelpeakfinding.h
 
+#For all platforms:
+INCLUDEPATH += $$PWD/include
+DEPENDPATH += $$PWD/include
 
 unix:!macx{
     QMAKE_CXX=/usr/bin/g++-4.9
+    CONFIG += c++11
+    QMAKE_CXXFLAGS += -fext-numeric-literals
     LIBS += -L$$PWD/../../mlpack/lib -lmlpack
     LIBS += -L$$PWD/../../armadillo/lib -larmadillo
     LIBS += -L/usr/lib -larpack
@@ -137,10 +142,13 @@ unix:!macx{
     PRE_TARGETDEPS += /usr/lib/x86_64-linux-gnu/libhdf5.a
     LIBS += -L/usr/lib -lblas
     LIBS += -L/usr/lib -llapack
-    LIBS += -L$$PWD/../../yaml-cpp/lib -llibyaml-cpp
+    LIBS += -L$$PWD/../../yaml-cpp/lib -lyaml-cpp
     PRE_TARGETDEPS += $$PWD/../../yaml-cpp/lib/libyaml-cpp.a
-    LIBS += -L$$PWD/../../quazip/lib -llibquazip
+    LIBS += -L$$PWD/../../quazip/lib -lquazip
     PRE_TARGETDEPS += $$PWD/../../quazip/lib/libquazip.a
+
+    LIBS += -L/usr/lib/x86_64-linux-gnu/ -lz
+    PRE_TARGETDEPS += /usr/lib/x86_64-linux-gnu/libz.a
 
     INCLUDEPATH += /usr/include
     DEPENDPATH += /usr/include
@@ -151,6 +159,17 @@ unix:!macx{
     INCLUDEPATH += /usr/local/include
     DEPENDPATH += /usr/local/include
 
+    INCLUDEPATH += $$PWD/../../mlpack/include
+    DEPENDPATH += $$PWD/../../mlpack/include
+
+    INCLUDEPATH += $$PWD/../../armadillo/include
+    DEPENDPATH += $$PWD/../../armadillo/include
+
+    INCLUDEPATH += $$PWD/../../quazip/include
+    DEPENDPATH += $$PWD/../../quazip/include
+
+    INCLUDEPATH += $$PWD/../../yaml-cpp/include
+    DEPENDPATH += $$PWD/../../yaml-cpp/include
 }
 
 #mac libraries. These are the same in Travis-CI as in most local environments

--- a/deploylinux.sh
+++ b/deploylinux.sh
@@ -13,11 +13,13 @@ buildDir=$2
 deploymentDir=$3
 libDir=$4
 
-if [! -f $deploymentDir ]; then mkdir $deploymentDir fi
-if [! -f $deploymentDir/bin ]; then mkdir $deploymentDir/bin fi
-if [! -f $deploymentDir/include ]; then mkdir $deploymentDir/include fi
-if [! -f $deploymentDir/lib ]; then mkdir $deploymentDir/lib fi
+if [ ! -f $deploymentDir ]; then mkdir $deploymentDir; fi
+if [ ! -f $deploymentDir/bin ]; then mkdir $deploymentDir/bin; fi
+if [ ! -f $deploymentDir/include ]; then mkdir $deploymentDir/include; fi
+if [ ! -f $deploymentDir/lib ]; then mkdir $deploymentDir/lib; fi
 
+cp $buildDir/Vespucci/vespucci $deploymentDir/bin
+find $buildDir/VespucciProject -name libvespucci.* -exec cp {} $deploymentDir/lib \;
 find $libDir/mlpack/lib -name \*.so -exec cp {} $deploymentDir/lib \;
-find $libDir/armadillo/lib -name \*.so -exec cp {} $deploymentDir/Contents/Frameworks $deploymentDir/ \;
+find $libDir/armadillo/lib -name \*.so -exec cp {} $deploymentDir/lib \;
 

--- a/getlinuxdeps.sh
+++ b/getlinuxdeps.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 wget https://github.com/VespucciProject/Vespucci_dependencies/releases/download/1/Vespucci_dependencies_linux.tar.gz
-tar xvf Vespucci_dependencies_linux.tar.gz -C /home/travis
+tar xvf Vespucci_dependencies_linux.tar.gz  
 sudo apt-add-repository -y ppa:ubuntu-sdk-team
 sudo apt-add-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt-add-repository -y ppa:beineri/opt-qt561-trusty
 sudo apt-get -y update
-sudo apt-get -y install qt56base qt56tools qt56imageformats qt56location qt56declarative libsqlite3-dev qt56svg
+sudo apt-get -y install g++-4.9 build-essential
+sudo apt-get -y install qt56base qt56tools qt56imageformats 
+sudo apt-get -y install qt56location qt56declarative libsqlite3-dev qt56svg
+sudo apt-get -y install mesa-common-dev freeglut3.dev
 sudo apt-get -y install libhdf5-dev libarpack2-dev
-sudo apt-get -y install libxml2-dev libboost1.55-dev libboost-math1.55-dev libboost-program-options1.55-dev libboost-test1.55-dev libboost-random1.55-dev
+sudo apt-get -y install libxml2-dev libboost1.55-dev libboost-math1.55-dev 
+sudo apt-get -y install libboost1.55-all-dev
+sudo apt-get -y install zlib1g zlib1g-dev

--- a/getosxdeps.sh
+++ b/getosxdeps.sh
@@ -11,7 +11,7 @@ brew link qt5
 brew link hdf5
 brew link libxml2
 brew link arpack
-brew link superlu43
+brew link --force superlu43
 brew link wget
 wget https://github.com/VespucciProject/Vespucci_dependencies/releases/download/1/Vespucci_dependencies_macOS.zip
 unzip Vespucci_dependencies_macOS.zip


### PR DESCRIPTION
- fixed dumb error in .travis.yml
- Fixed stupid error that I made while fixing previous stupid error in
  .travis.yml
- fixed yet another mistake made while fixing the last mistake...
- fixed syntax errors in .travis.yml
- A missing semicolon added
- Fixed not being able to find qmake on macOS Travis-CI builds.
- fixed a dumb mistake...
- forgot to install g++ 4.9 on travis CI
- Forgot that SuperLU was keg-only in homebrew. (though we don't use it at
  all in Vespucci and it isn't used in the windows or linux builds)
- Forgot a -y flag on apt-get.
- Didn't set up include paths for linux
- Forgot to require C++11 on linux.
- Fixed an issue with g++ that I haven't come across yet.
- Fixed some dumb mistakes.
- added the -fext-numeric-literals flag to the other two qt profiles
- Making sure the OpenGL headers exist for QtSVG support.
- Fixes to linux build
- Forgot to copy the binary to the deployment directory ¯_(ツ)_/¯
- linux fix
- forgot i needed to link zlib on linux...
- installing all boost (will be cached by Travis CI anyway)
- fixed error in .travis.yml
- update README.md
